### PR TITLE
Merge elementwise into master

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, divide
+from __future__ import print_function, division
 from numpy import asarray, unravel_index, prod, mod, ndarray, ceil, where, \
     r_, sort, argsort, array, random, arange, ones, expand_dims, sum
 from itertools import groupby
@@ -1013,15 +1013,13 @@ class BoltArraySpark(BoltArray):
         for x in self._rdd.take(10):
             print(x)
 
-    def __add__(self, arry):
+   def __add__(self, arry):
         """
         Add this array element-wise with another array (arry).
-
         Paramters
         ---------
         arry : ndarray, BoltArrayLocal, or BoltArraySpark
             Another array to add element-wise
-
         Returns
         -------
         BoltArraySpark
@@ -1033,21 +1031,19 @@ class BoltArraySpark(BoltArray):
             if not isinstance(arry, BoltArraySpark):
                 raise ValueError("other must be local array or spark array, got %s" % type(arry))
 
-        if not all([x == y]):
-            raise ValueError("all the input array dimensions must match exactly")
+        if not all([x == y for (x,y) in zip(self.shape, arry.shape)]):
+            raise ValueError("All the input array dimensions must match exactly")
             
         rdd = self._rdd.join(arry._rdd).mapValues(lambda x: x[0] + x[1])
         return self._constructor(rdd).__finalize__(self)
-        
+
     def __sub__(self, arry):
         """
         Subtract another array (arry) element-wise from this array.
-
         Paramters
         ---------
         arry : ndarray, BoltArrayLocal, or BoltArraySpark
             Another array to subtract element-wise
-
         Returns
         -------
         BoltArraySpark
@@ -1059,21 +1055,19 @@ class BoltArraySpark(BoltArray):
             if not isinstance(arry, BoltArraySpark):
                 raise ValueError("other must be local array or spark array, got %s" % type(arry))
 
-        if not all([x == y]):
-            raise ValueError("all the input array dimensions must match exactly")
+        if not all([x == y for (x,y) in zip(self.shape, arry.shape)]):
+            raise ValueError("All the input array dimensions must match exactly")
             
         rdd = self._rdd.join(arry._rdd).mapValues(lambda x: x[0] - x[1])
         return self._constructor(rdd).__finalize__(self)
-        
+
     def __mul__(self, arry):
         """
         Multiply this array element-wise with another array (arry).
-
         Paramters
         ---------
         arry : ndarray, BoltArrayLocal, or BoltArraySpark
             Another array to multiply element-wise
-
         Returns
         -------
         BoltArraySpark
@@ -1085,21 +1079,19 @@ class BoltArraySpark(BoltArray):
             if not isinstance(arry, BoltArraySpark):
                 raise ValueError("other must be local array or spark array, got %s" % type(arry))
 
-        if not all([x == y]):
-            raise ValueError("all the input array dimensions must match exactly")
+        if not all([x == y for (x,y) in zip(self.shape, arry.shape)]):
+            raise ValueError("All the input array dimensions must match exactly")
             
         rdd = self._rdd.join(arry._rdd).mapValues(lambda x: x[0] * x[1])
         return self._constructor(rdd).__finalize__(self)
-        
-    def __truediv__(self, arry):
-        """
-        Divide this array by another array (arry) element-wise.
 
+    def __div__(self, arry):
+        """
+        Divide this array by another array (arry) element-wise.  Always use true division
         Paramters
         ---------
         arry : ndarray, BoltArrayLocal, or BoltArraySpark
             Another array to divide by element-wise
-
         Returns
         -------
         BoltArraySpark
@@ -1111,9 +1103,21 @@ class BoltArraySpark(BoltArray):
             if not isinstance(arry, BoltArraySpark):
                 raise ValueError("other must be local array or spark array, got %s" % type(arry))
 
-        if not all([x == y]):
-            raise ValueError("all the input array dimensions must match exactly")
+        if not all([x == y for (x,y) in zip(self.shape, arry.shape)]):
+            raise ValueError("All the input array dimensions must match exactly")
         
-        from future import division
         rdd = self._rdd.join(arry._rdd).mapValues(lambda x: x[0] / x[1])
         return self._constructor(rdd).__finalize__(self)
+
+    def __truediv__(self, arry):
+        """
+        If true division all ready imported, just use division, as true division is imported there
+        Paramters
+        ---------
+        arry : ndarray, BoltArrayLocal, or BoltArraySpark
+            Another array to divide by element-wise
+        Returns
+        -------
+        BoltArraySpark
+        """
+        return self.__div__(arry)


### PR DESCRIPTION
Fixed **truediv** functionality.  Submitted this as a patch to the main branch with the following note:

Added basic element-wise addition (+), subtraction (-), multiplication (*), and division (/) to BoltSparkArrays.

Method used is `_rdd().join().mapValues()`.  Attempted to play around with `_rdd().cogroup().reduceByKey()` but `cogroup()` returns interables and I was not familiar enough with them to spend the time troubleshooting other methods for a time efficiency comparison.  May be a better method to implement these operations, but I went with the best I knew how.

I didn't include any of the reverse functions (**radd** etc) as I wasn't sure how it would behave/interact with local array functions if there was an attempt to list the local array first (`local + Spark`). There are no issues as long as it is always two arrays being added together and the Spark array is listed first (`Spark + local`).

I also didn't add support for adding/subtracting/multiplying/dividing by a constant integer across the whole array.  I wasn't sure if this is functionality we would want to add, as it can be done using `map()`.  My personal opinion is to require the user to use `map()` because I feel it forces the user to remember they are working on distributed arrays.  However, this functionality could be easily implemented into the existing functions with some if statements in checking for integers and doing the `map()` under the hood.

On a similar note to above, these functions could also be changed to not use the symbolic values (+, -, *, /) but be calls required in a map format (`.add()`, `.subtract()`, `multiply()`, `divide()`).

Finally, if there is an intention to add many operations for distributed BoltSparkArrays similar to all the functions for python ndarrays, perhaps an independent class or .py file should be created to contain these operations that could then be called?  I wasn't sure of the long-term intentions of what types of functions there is an interest to integrate into BoltArrays.

Tried to include similar safety catches as `concatenate()`.

For division, true division from **future** is always performed.

Basic troubleshooting was performed without any major issues, but more thorough troubleshooting may be useful.
